### PR TITLE
iOS 16+ compatibility - use background instead of voip flags

### DIFF
--- a/Core/XMPPStream.h
+++ b/Core/XMPPStream.h
@@ -264,7 +264,7 @@ extern const NSTimeInterval XMPPStreamTimeoutNone;
 #if TARGET_OS_IPHONE
 
 /**
- * If set, the kCFStreamNetworkServiceTypeVoIP flags will be set on the underlying CFRead/Write streams.
+ * If set, the kCFStreamNetworkServiceTypeBackground flags will be set on the underlying CFRead/Write streams.
  * 
  * The default value is NO.
 **/

--- a/Core/XMPPStream.h
+++ b/Core/XMPPStream.h
@@ -264,7 +264,7 @@ extern const NSTimeInterval XMPPStreamTimeoutNone;
 #if TARGET_OS_IPHONE
 
 /**
- * If set, the kCFStreamNetworkServiceTypeBackground flags will be set on the underlying CFRead/Write streams.
+ * If set, kCFStreamNetworkServiceTypeVoIP (or kCFStreamNetworkServiceTypeBackground for iOS 16+) flags will be set on the underlying CFRead/Write streams.
  * 
  * The default value is NO.
 **/

--- a/Vendor/CocoaAsyncSocket/GCDAsyncSocket.h
+++ b/Vendor/CocoaAsyncSocket/GCDAsyncSocket.h
@@ -948,8 +948,8 @@ typedef enum GCDAsyncSocketError GCDAsyncSocketError;
  * Configures the socket to allow it to operate when the iOS application has been backgrounded.
  * In other words, this method creates a read & write stream, and invokes:
  * 
- * CFReadStreamSetProperty(readStream, kCFStreamNetworkServiceType, kCFStreamNetworkServiceTypeVoIP);
- * CFWriteStreamSetProperty(writeStream, kCFStreamNetworkServiceType, kCFStreamNetworkServiceTypeVoIP);
+ * CFReadStreamSetProperty(readStream, kCFStreamNetworkServiceType, kCFStreamNetworkServiceTypeBackground);
+ * CFWriteStreamSetProperty(writeStream, kCFStreamNetworkServiceType, kCFStreamNetworkServiceTypeBackground);
  * 
  * Returns YES if successful, NO otherwise.
  * 

--- a/Vendor/CocoaAsyncSocket/GCDAsyncSocket.h
+++ b/Vendor/CocoaAsyncSocket/GCDAsyncSocket.h
@@ -948,6 +948,9 @@ typedef enum GCDAsyncSocketError GCDAsyncSocketError;
  * Configures the socket to allow it to operate when the iOS application has been backgrounded.
  * In other words, this method creates a read & write stream, and invokes:
  * 
+ * CFReadStreamSetProperty(readStream, kCFStreamNetworkServiceType, kCFStreamNetworkServiceTypeVoIP);
+ * CFWriteStreamSetProperty(writeStream, kCFStreamNetworkServiceType, kCFStreamNetworkServiceTypeVoIP);
+ *   If the target device is iOS and is version 16+, these will be invoked instead:
  * CFReadStreamSetProperty(readStream, kCFStreamNetworkServiceType, kCFStreamNetworkServiceTypeBackground);
  * CFWriteStreamSetProperty(writeStream, kCFStreamNetworkServiceType, kCFStreamNetworkServiceTypeBackground);
  * 

--- a/Vendor/CocoaAsyncSocket/GCDAsyncSocket.m
+++ b/Vendor/CocoaAsyncSocket/GCDAsyncSocket.m
@@ -2334,7 +2334,7 @@ enum GCDAsyncSocketConfig
 	// 
 	// Note:
 	// There may be configuration options that must be set by the delegate before opening the streams.
-	// The primary example is the kCFStreamNetworkServiceTypeVoIP flag, which only works on an unopened stream.
+	// The primary example is the kCFStreamNetworkServiceTypeBackground flag, which only works on an unopened stream.
 	// 
 	// Thus we wait until after the socket:didConnectToHost:port: delegate method has completed.
 	// This gives the delegate time to properly configure the streams if needed.
@@ -7406,8 +7406,8 @@ static void CFWriteStreamCallback (CFWriteStreamRef stream, CFStreamEventType ty
 	
 	LogVerbose(@"Enabling backgrouding on socket");
 	
-	r1 = CFReadStreamSetProperty(readStream, kCFStreamNetworkServiceType, kCFStreamNetworkServiceTypeVoIP);
-	r2 = CFWriteStreamSetProperty(writeStream, kCFStreamNetworkServiceType, kCFStreamNetworkServiceTypeVoIP);
+	r1 = CFReadStreamSetProperty(readStream, kCFStreamNetworkServiceType, kCFStreamNetworkServiceTypeBackground);
+	r2 = CFWriteStreamSetProperty(writeStream, kCFStreamNetworkServiceType, kCFStreamNetworkServiceTypeBackground);
 	
 	if (!r1 || !r2)
 	{


### PR DESCRIPTION
More specifically, if on iOS, and the version is 16+, use
`kCFStreamNetworkServiceTypeBackground` instead of 
`kCFStreamNetworkServiceTypeVoIP`. Note that both are still
deprecated, but the voip one is shot dead by the OS.